### PR TITLE
Add preview scroll speed setting

### DIFF
--- a/src/main/java/log/charter/data/config/GraphicalConfig.java
+++ b/src/main/java/log/charter/data/config/GraphicalConfig.java
@@ -60,6 +60,7 @@ public class GraphicalConfig {
 	public static int noteHeight = 25;
 	public static int handShapesHeight = 12;
 	public static int timingHeight = 40;
+	public static double previewWindowScrollSpeed = 1.3; // Same as default for Rocksmith
 
 	public static String inlay = "default";
 	public static String texturePack = "default";
@@ -86,6 +87,8 @@ public class GraphicalConfig {
 
 		valueAccessors.put("inlay", ValueAccessor.forString(v -> inlay = v, () -> inlay));
 		valueAccessors.put("textures", ValueAccessor.forString(v -> texturePack = v, () -> texturePack));
+		valueAccessors.put("previewWindowScrollSpeed",
+				ValueAccessor.forDouble(v -> previewWindowScrollSpeed = v, () -> previewWindowScrollSpeed));
 	}
 
 	public static void init() {

--- a/src/main/java/log/charter/data/config/Localization.java
+++ b/src/main/java/log/charter/data/config/Localization.java
@@ -47,6 +47,7 @@ public class Localization {
 		GRAPHIC_CONFIG_NOTE_WIDTH("Note width (px)"), //
 		GRAPHIC_CONFIG_HAND_SHAPES_HEIGHT("Hand shapes height"), //
 		GRAPHIC_CONFIG_TIMING_HEIGHT("Timing height"), //
+		GRAPHIC_CONFIG_PREVIEW_SCROLL_SPEED("Preview scroll speed"), //
 
 		GRAPHIC_CONFIG_TEXTURES_PAGE("Textures"), //
 		GRAPHIC_CONFIG_INLAY("Inlay"), //

--- a/src/main/java/log/charter/gui/components/preview3D/Preview3DUtils.java
+++ b/src/main/java/log/charter/gui/components/preview3D/Preview3DUtils.java
@@ -1,11 +1,9 @@
 package log.charter.gui.components.preview3D;
 
 import log.charter.data.config.Config;
+import log.charter.data.config.GraphicalConfig;
 
 public class Preview3DUtils {
-	public static final int visibility = 3_000;
-	public static final double timeZMultiplier = 0.01;
-	public static final double visibilityZ = getTimePosition(visibility);
 	public static final double topStringPosition = 0;
 	public static final double fretThickness = 0.025;
 	public static final double firstFretDistance = 1.2;
@@ -44,6 +42,15 @@ public class Preview3DUtils {
 		return fretPositions[fret];
 	}
 
+	// Gives similar visibility to Rocksmith, 1.3 -> 4 bars at 120 bpm, 1.0 -> 3 bars at 120 bpm
+	public static int getVisibility() {
+		return (int)(1_600 * GraphicalConfig.previewWindowScrollSpeed);
+	}
+
+	public static double getVisibilityZ() {
+		return getTimePosition(getVisibility());
+	}
+
 	public static double getFretMiddlePosition(final int fret) {
 		return (getFretPosition(fret - 1) + getFretPosition(fret)) / 2;
 	}
@@ -65,6 +72,7 @@ public class Preview3DUtils {
 	}
 
 	public static double getTimePosition(final int time) {
-		return time * timeZMultiplier;
+		// 0.02 is subjective and might need adjustments if camera perspective is edited
+		return (time * 0.02) / GraphicalConfig.previewWindowScrollSpeed;
 	}
 }

--- a/src/main/java/log/charter/gui/components/preview3D/data/Preview3DDrawData.java
+++ b/src/main/java/log/charter/gui/components/preview3D/data/Preview3DDrawData.java
@@ -1,6 +1,6 @@
 package log.charter.gui.components.preview3D.data;
 
-import static log.charter.gui.components.preview3D.Preview3DUtils.visibility;
+import static log.charter.gui.components.preview3D.Preview3DUtils.getVisibility;
 import static log.charter.gui.components.preview3D.data.AnchorDrawData.getAnchorsForTimeSpanWithRepeats;
 import static log.charter.gui.components.preview3D.data.BeatDrawData.getBeatsForTimeSpanWithRepeats;
 import static log.charter.gui.components.preview3D.data.HandShapeDrawData.getHandShapesForTimeSpanWithRepeats;
@@ -30,7 +30,7 @@ public class Preview3DDrawData {
 
 	public Preview3DDrawData(final ChartData data, final RepeatManager repeatManager) {
 		final int timeFrom = data.time;
-		final int timeTo = data.time + visibility;
+		final int timeTo = data.time + getVisibility();
 
 		if (data.getCurrentArrangementLevel() == null) {
 			levelAnchors = new ArrayList2<>(new Anchor(0, 1));

--- a/src/main/java/log/charter/gui/components/preview3D/drawers/Preview3DHandShapesDrawer.java
+++ b/src/main/java/log/charter/gui/components/preview3D/drawers/Preview3DHandShapesDrawer.java
@@ -8,7 +8,7 @@ import static log.charter.gui.components.preview3D.Preview3DUtils.fretThickness;
 import static log.charter.gui.components.preview3D.Preview3DUtils.getChartboardYPosition;
 import static log.charter.gui.components.preview3D.Preview3DUtils.getFretPosition;
 import static log.charter.gui.components.preview3D.Preview3DUtils.getTimePosition;
-import static log.charter.gui.components.preview3D.Preview3DUtils.visibility;
+import static log.charter.gui.components.preview3D.Preview3DUtils.getVisibility;
 
 import java.awt.Color;
 
@@ -61,7 +61,7 @@ public class Preview3DHandShapesDrawer {
 		final boolean arpeggio = handShape.template.arpeggio;
 
 		final int timeFrom = max(0, handShape.timeFrom - data.time);
-		final int timeTo = min(visibility, handShape.timeTo - data.time);
+		final int timeTo = min(getVisibility(), handShape.timeTo - data.time);
 		if (timeTo < 0) {
 			return;
 		}

--- a/src/main/java/log/charter/gui/components/preview3D/drawers/Preview3DLaneBordersDrawer.java
+++ b/src/main/java/log/charter/gui/components/preview3D/drawers/Preview3DLaneBordersDrawer.java
@@ -6,7 +6,7 @@ import static log.charter.gui.components.preview3D.Preview3DUtils.fadedDistanceZ
 import static log.charter.gui.components.preview3D.Preview3DUtils.fretThickness;
 import static log.charter.gui.components.preview3D.Preview3DUtils.getChartboardYPosition;
 import static log.charter.gui.components.preview3D.Preview3DUtils.getFretPosition;
-import static log.charter.gui.components.preview3D.Preview3DUtils.visibilityZ;
+import static log.charter.gui.components.preview3D.Preview3DUtils.getVisibilityZ;
 import static log.charter.util.ColorUtils.setAlpha;
 
 import java.awt.Color;
@@ -36,12 +36,12 @@ public class Preview3DLaneBordersDrawer {
 		final double x1 = x + fretThickness;
 
 		shadersHolder.new FadingShaderDrawData()//
-				.addVertex(new Point3D(x, y, visibilityZ), color)//
+				.addVertex(new Point3D(x, y, getVisibilityZ()), color)//
 				.addVertex(new Point3D(x, y, 0), color)//
 				.draw(GL33.GL_LINES, Matrix4.identity, closeDistanceZ, 0);
 		shadersHolder.new FadingShaderDrawData()//
-				.addVertex(new Point3D(x0, y, visibilityZ), color)//
-				.addVertex(new Point3D(x1, y, visibilityZ), color)//
+				.addVertex(new Point3D(x0, y, getVisibilityZ()), color)//
+				.addVertex(new Point3D(x1, y, getVisibilityZ()), color)//
 				.addVertex(new Point3D(x0, y, 0), color)//
 				.addVertex(new Point3D(x1, y, 0), color)//
 				.draw(GL33.GL_TRIANGLE_STRIP, Matrix4.identity, closeDistanceZ, fadedDistanceZ);

--- a/src/main/java/log/charter/gui/panes/graphicalConfig/GraphicThemeConfigPage.java
+++ b/src/main/java/log/charter/gui/panes/graphicalConfig/GraphicThemeConfigPage.java
@@ -3,6 +3,7 @@ package log.charter.gui.panes.graphicalConfig;
 import static java.util.Arrays.asList;
 import static log.charter.gui.components.TextInputSelectAllOnFocus.addSelectTextOnFocus;
 
+import java.math.BigDecimal;
 import java.util.Vector;
 
 import javax.swing.JComboBox;
@@ -15,6 +16,7 @@ import log.charter.gui.components.FieldWithLabel;
 import log.charter.gui.components.FieldWithLabel.LabelPosition;
 import log.charter.gui.components.Page;
 import log.charter.gui.components.TextInputWithValidation;
+import log.charter.gui.components.TextInputWithValidation.BigDecimalValueValidator;
 import log.charter.gui.components.TextInputWithValidation.IntegerValueValidator;
 
 public class GraphicThemeConfigPage implements Page {
@@ -41,6 +43,7 @@ public class GraphicThemeConfigPage implements Page {
 	private int noteWidth = GraphicalConfig.noteWidth;
 	private int handShapesHeight = GraphicalConfig.handShapesHeight;
 	private int timingHeight = GraphicalConfig.timingHeight;
+	private BigDecimal previewScrollSpeed = BigDecimal.valueOf(GraphicalConfig.previewWindowScrollSpeed);
 
 	private FieldWithLabel<JComboBox<ThemeHolder>> themeField;
 	private FieldWithLabel<TextInputWithValidation> noteHeightField;
@@ -49,6 +52,7 @@ public class GraphicThemeConfigPage implements Page {
 	private FieldWithLabel<TextInputWithValidation> anchorInfoHeightField;
 	private FieldWithLabel<TextInputWithValidation> handShapesHeightField;
 	private FieldWithLabel<TextInputWithValidation> timingHeightField;
+	private FieldWithLabel<TextInputWithValidation> previewScrollSpeedField;
 
 	public void init(final GraphicConfigPane parent, int row) {
 		addThemePicker(parent, row++);
@@ -61,6 +65,7 @@ public class GraphicThemeConfigPage implements Page {
 
 		addHandShapesHeightFieldField(parent, row);
 		addTimingHeightFieldField(parent, row++);
+		addScrollSpeedFieldField(parent, row);
 
 		hide();
 	}
@@ -175,6 +180,18 @@ public class GraphicThemeConfigPage implements Page {
 		parent.add(timingHeightField);
 	}
 
+	private void addScrollSpeedFieldField(final GraphicConfigPane parent, final int row) {
+		final TextInputWithValidation input = new TextInputWithValidation(previewScrollSpeed, 20,
+				new BigDecimalValueValidator(new BigDecimal("0.1"), new BigDecimal("2.0"), false), i -> previewScrollSpeed = i, false);
+		input.setHorizontalAlignment(JTextField.CENTER);
+		addSelectTextOnFocus(input);
+
+		previewScrollSpeedField = new FieldWithLabel<>(Label.GRAPHIC_CONFIG_PREVIEW_SCROLL_SPEED, 120, 30, 20, input,
+				LabelPosition.LEFT_CLOSE);
+				previewScrollSpeedField.setLocation(10, parent.getY(row));
+		parent.add(previewScrollSpeedField);
+	}
+
 	@Override
 	public void show() {
 		themeField.setVisible(true);
@@ -184,6 +201,7 @@ public class GraphicThemeConfigPage implements Page {
 		noteWidthField.setVisible(theme != Theme.MODERN);
 		handShapesHeightField.setVisible(true);
 		timingHeightField.setVisible(true);
+		previewScrollSpeedField.setVisible(true);
 	}
 
 	@Override
@@ -195,6 +213,7 @@ public class GraphicThemeConfigPage implements Page {
 		noteWidthField.setVisible(false);
 		handShapesHeightField.setVisible(false);
 		timingHeightField.setVisible(false);
+		previewScrollSpeedField.setVisible(false);
 	}
 
 	public void save() {
@@ -205,5 +224,6 @@ public class GraphicThemeConfigPage implements Page {
 		GraphicalConfig.noteWidth = noteWidth;
 		GraphicalConfig.handShapesHeight = handShapesHeight;
 		GraphicalConfig.timingHeight = timingHeight;
+		GraphicalConfig.previewWindowScrollSpeed = previewScrollSpeed.doubleValue();
 	}
 }


### PR DESCRIPTION
Add a preview scroll speed setting into the graphical config menu. It tries to match Rocksmith in that it stretches note distance based on visibility range. It might need fine-tuning if the camera perspective changes.

Tested values:
1.3 -> ~4 bars visibility at 120 bpm
1.0 -> ~3 bars visibility at 120 bpm
